### PR TITLE
Itertools count

### DIFF
--- a/itertools.go
+++ b/itertools.go
@@ -80,16 +80,12 @@ func count_(
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
 	var (
-		stateValue int
-		stepValue  int
+		start int
+		step  int
 	)
 
-	// If length of args is 0, then use `itertools.count()`s default
-	// values.
-	// If length of args is 2, use said args.
-	// Otherwise, return an error.
 	if err := starlark.UnpackPositionalArgs(
-		"count", args, kwargs, 0, &stateValue, &stepValue,
+		"count", args, kwargs, 0, &start, &step,
 	); err != nil {
 		return nil, fmt.Errorf(
 			`Got %v but expected NoneType or valid
@@ -97,12 +93,23 @@ func count_(
 		)
 	}
 
+	const (
+		defaultStart = 0
+		defaultStep  = 1
+	)
+	// The rules for populating the count object based on the number
+	// of args passed is as follows:
+	// 	0 args -> default values for start and step
+	// 	1 args -> arg defines start, default for step
+	// 	2 args -> both start and step are defined by args
 	var co_ *countObject
 	switch nargs := len(args); {
 	case nargs == 0:
-		co_ = newCountObject(0, 1)
+		co_ = newCountObject(defaultStart, defaultStep)
+	case nargs == 1:
+		co_ = newCountObject(start, defaultStep)
 	default: // nargs == 2
-		co_ = newCountObject(stateValue, stepValue)
+		co_ = newCountObject(start, step)
 	}
 
 	return co_, nil

--- a/itertools.go
+++ b/itertools.go
@@ -97,7 +97,7 @@ func count_(
 		)
 	}
 
-	co_ := &countObject{}
+	var co_ *countObject
 	switch nargs := len(args); {
 	case nargs == 0:
 		co_ = newCountObject(0, 1)

--- a/itertools.go
+++ b/itertools.go
@@ -14,7 +14,6 @@ var ItertoolsModule = &starlarkstruct.Module{
 	},
 }
 
-// countObject as starlark.Value interface
 type countObject struct {
 	cnt    int
 	step   int
@@ -55,7 +54,10 @@ func (co *countObject) Hash() (uint32, error) {
 	return uint32(10), nil
 }
 
-// countIter as starlark.Iterator interface
+func (co *countObject) Iterate() starlark.Iterator {
+	return &countIter{co: co}
+}
+
 type countIter struct {
 	co *countObject
 }
@@ -70,11 +72,6 @@ func (c *countIter) Next(p *starlark.Value) bool {
 }
 
 func (c *countIter) Done() {}
-
-// Make countObject an Iterable
-func (co *countObject) Iterate() starlark.Iterator {
-	return &countIter{co: co}
-}
 
 func count_(
 	thread *starlark.Thread,

--- a/itertools.go
+++ b/itertools.go
@@ -88,8 +88,8 @@ func count_(
 		"count", args, kwargs, 0, &start, &step,
 	); err != nil {
 		return nil, fmt.Errorf(
-			`Got %v but expected NoneType or valid
-	integer values for start and step, such as (0, 1).`, args,
+			`%w; Got %v but expected NoneType or valid
+	integer values for start and step, such as (0, 1).`, err, args,
 		)
 	}
 

--- a/itertools.go
+++ b/itertools.go
@@ -1,0 +1,112 @@
+package sun
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+var ItertoolsModule = &starlarkstruct.Module{
+	Name: "itertools",
+	Members: starlark.StringDict{
+		"count": starlark.NewBuiltin("itertools.count", count_),
+	},
+}
+
+// countObject as starlark.Value interface
+type countObject struct {
+	cnt    int
+	step   int
+	frozen bool
+	value  starlark.Value
+}
+
+func newCountObject(cnt int, stepValue int) *countObject {
+	return &countObject{cnt: cnt, step: stepValue, value: starlark.MakeInt(cnt)}
+}
+
+func (co *countObject) String() string {
+	// As with the cpython implementation, we don't display
+	// step when it is an integer equal to 1.
+	if co.step == 1 {
+		return fmt.Sprintf("count(%v)", co.cnt)
+	}
+	return fmt.Sprintf("count(%v, %v)", co.cnt, co.step)
+}
+
+func (co *countObject) Type() string {
+	return "itertools.count"
+}
+
+func (co *countObject) Freeze() {
+	if !co.frozen {
+		co.frozen = true
+		co.value.Freeze()
+	}
+}
+
+func (co *countObject) Truth() starlark.Bool {
+	return starlark.True
+}
+
+func (co *countObject) Hash() (uint32, error) {
+	// TODO(algebra8): Implement inherited type object hash.
+	return uint32(10), nil
+}
+
+// countIter as starlark.Iterator interface
+type countIter struct {
+	co *countObject
+}
+
+func (c *countIter) Next(p *starlark.Value) bool {
+	if c.co.frozen {
+		return false
+	}
+	*p = starlark.MakeInt(c.co.cnt)
+	c.co.cnt += c.co.step
+	return true
+}
+
+func (c *countIter) Done() {}
+
+// Make countObject an Iterable
+func (co *countObject) Iterate() starlark.Iterator {
+	return &countIter{co: co}
+}
+
+func count_(
+	thread *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var (
+		stateValue int
+		stepValue  int
+	)
+
+	// If length of args is 0, then use `itertools.count()`s default
+	// values.
+	// If length of args is 2, use said args.
+	// Otherwise, return an error.
+	if err := starlark.UnpackPositionalArgs(
+		"count", args, kwargs, 0, &stateValue, &stepValue,
+	); err != nil {
+		return nil, fmt.Errorf(
+			`Got %v but expected NoneType or valid
+	integer values for start and step, such as (0, 1).`, args,
+		)
+	}
+
+	co_ := &countObject{}
+	switch nargs := len(args); {
+	case nargs == 0:
+		co_ = newCountObject(0, 1)
+	default: // nargs == 2
+		co_ = newCountObject(stateValue, stepValue)
+	}
+
+	return co_, nil
+}

--- a/itertools.go
+++ b/itertools.go
@@ -88,8 +88,8 @@ func count_(
 		"count", args, kwargs, 0, &start, &step,
 	); err != nil {
 		return nil, fmt.Errorf(
-			`%w; Got %v but expected NoneType or valid
-	integer values for start and step, such as (0, 1).`, err, args,
+			"Got %v but expected NoneType or valid integer values for "+
+				"start and step, such as (0, 1).", args.String(),
 		)
 	}
 

--- a/itertools.go
+++ b/itertools.go
@@ -4,15 +4,7 @@ import (
 	"fmt"
 
 	"go.starlark.net/starlark"
-	"go.starlark.net/starlarkstruct"
 )
-
-var ItertoolsModule = &starlarkstruct.Module{
-	Name: "itertools",
-	Members: starlark.StringDict{
-		"count": starlark.NewBuiltin("itertools.count", count_),
-	},
-}
 
 type countObject struct {
 	cnt    int

--- a/itertools_test.go
+++ b/itertools_test.go
@@ -1,0 +1,9 @@
+package sun
+
+import (
+	"testing"
+)
+
+func TestItertools(t *testing.T) {
+	runTestData(t, "itertools.star")
+}

--- a/module.go
+++ b/module.go
@@ -18,3 +18,11 @@ var Module = &starlarkstruct.Module{
 		"bin":      starlark.NewBuiltin("bin", bin),
 	},
 }
+
+// Module itertools is a Starlark module of Python's itertools module.
+var ItertoolsModule = &starlarkstruct.Module{
+	Name: "itertools",
+	Members: starlark.StringDict{
+		"count": starlark.NewBuiltin("itertools.count", count_),
+	},
+}

--- a/sun_test.go
+++ b/sun_test.go
@@ -21,6 +21,16 @@ func runTestData(t *testing.T, name string) {
 	SetReporter(thread, t)
 
 	filename := filepath.Join("testdata", name)
+
+	// "Merge" ItertoolsModule and Module so ExecFile can use both
+	// predeclared names.
+	// The below method is surely not the correct way to accomplish
+	// the task but works for testing purposes.
+	// TODO(algebra8): Find and implement correct method for merging modules
+	for k, v := range ItertoolsModule.Members {
+		Module.Members[k] = v
+	}
+
 	if _, err := starlark.ExecFile(thread, filename, nil, Module.Members); err != nil {
 		if err, ok := err.(*starlark.EvalError); ok {
 			t.Fatal(err.Backtrace())

--- a/testdata/itertools.star
+++ b/testdata/itertools.star
@@ -29,5 +29,19 @@ def test_count():
     assert.eq(str(c2), "count(11, 3)")
     assert.eq(next(c2), 11)
 
+    # Fails
+    z = ("a", "b")
+    assert.fails(
+        lambda: count("a", "b"),
+        # fails uses match under the hood, which will use
+        # regexp.MatchString, so need to use raw pattern
+        # that MatchString would eaccept.
+        r'Got \(\"a\", \"b\"\)',
+    )
+    assert.fails(
+        lambda: count(1, 2, 3),
+        r'Got \(1, 2, 3\)'
+    )
+
 
 test_count()

--- a/testdata/itertools.star
+++ b/testdata/itertools.star
@@ -3,7 +3,8 @@ load("assert.star", "assert")
 
 def test_count():
 
-    c0 = count(0, 1)
+    # No args — defaults to 0, 1.
+    c0 = count()
     # *step* is omitted when 1. This is equivalent to count(start).
     assert.eq(str(c0), "count(0)")
     assert.eq(next(c0), 0)
@@ -11,13 +12,14 @@ def test_count():
     assert.eq(next(c0), 1)
     assert.eq(str(c0), "count(2)")
 
-    c1 = count(0, 5)
-    assert.eq(str(c1), "count(0, 5)")
-    assert.eq(next(c1), 0)
-    assert.eq(str(c1), "count(5, 5)")
+    # Only one arg — step defaults to 1.
+    c1 = count(5)
+    assert.eq(str(c1), "count(5)")
     assert.eq(next(c1), 5)
-    assert.eq(str(c1), "count(10, 5)")
-    assert.eq(next(c1), 10)
+    assert.eq(str(c1), "count(6)")
+    assert.eq(next(c1), 6)
+    assert.eq(str(c1), "count(7)")
+    assert.eq(next(c1), 7)
 
     c2 = count(5, 3)
     assert.eq(str(c2), "count(5, 3)")

--- a/testdata/itertools.star
+++ b/testdata/itertools.star
@@ -35,7 +35,7 @@ def test_count():
         lambda: count("a", "b"),
         # fails uses match under the hood, which will use
         # regexp.MatchString, so need to use raw pattern
-        # that MatchString would eaccept.
+        # that MatchString would accept.
         r'Got \(\"a\", \"b\"\)',
     )
     assert.fails(

--- a/testdata/itertools.star
+++ b/testdata/itertools.star
@@ -1,0 +1,31 @@
+load("assert.star", "assert")
+
+
+def test_count():
+
+    c0 = count(0, 1)
+    # *step* is omitted when 1. This is equivalent to count(start).
+    assert.eq(str(c0), "count(0)")
+    assert.eq(next(c0), 0)
+    assert.eq(str(c0), "count(1)")
+    assert.eq(next(c0), 1)
+    assert.eq(str(c0), "count(2)")
+
+    c1 = count(0, 5)
+    assert.eq(str(c1), "count(0, 5)")
+    assert.eq(next(c1), 0)
+    assert.eq(str(c1), "count(5, 5)")
+    assert.eq(next(c1), 5)
+    assert.eq(str(c1), "count(10, 5)")
+    assert.eq(next(c1), 10)
+
+    c2 = count(5, 3)
+    assert.eq(str(c2), "count(5, 3)")
+    assert.eq(next(c2), 5)
+    assert.eq(str(c2), "count(8, 3)")
+    assert.eq(next(c2), 8)
+    assert.eq(str(c2), "count(11, 3)")
+    assert.eq(next(c2), 11)
+
+
+test_count()


### PR DESCRIPTION
In this PR, functionality and tests for `itertools.count` is included and is related to #8.