### PR TITLE
Itertools count float input

### DIFF
--- a/itertools.go
+++ b/itertools.go
@@ -73,7 +73,7 @@ func (c *countIter) Next(p *starlark.Value) bool {
 	*p = c.co.cnt.value
 
 	if e := c.co.cnt.add(c.co.step); e != nil {
-		panic(e)
+		return false
 	}
 
 	return true
@@ -93,7 +93,7 @@ func (co countObject) String() string {
 	step, ok := co.step.value.(starlark.Int)
 	if ok {
 		if x, ok := step.Int64(); ok && x == 1 {
-		         return "count(1)"
+			return "count(1)"
 		}
 	}
 

--- a/itertools.go
+++ b/itertools.go
@@ -38,26 +38,30 @@ func (p *floatOrInt) Unpack(v starlark.Value) error {
 
 func (fi *floatOrInt) add(n floatOrInt) error {
 	switch {
+	// fi is int; n is int
 	case fi.i_ != nil && n.i_ != nil:
 		x := fi.i_.Add(*n.i_)
 		fi.i_ = &x
 		return nil
+	// fi is int; n is float
 	case fi.i_ != nil && n.f_ != nil:
 		x := starlark.Float(float64(fi.i_.Float()) + float64(*n.f_))
 		fi.f_ = &x
 		fi.i_ = nil
 		return nil
+	// fi is float; n is int
 	case fi.f_ != nil && n.i_ != nil:
 		x := starlark.Float(float64(*fi.f_) + float64(n.i_.Float()))
 		fi.f_ = &x
 		fi.i_ = nil
 		return nil
+	// fi is float; n is float
 	case fi.f_ != nil && n.f_ != nil:
 		x := starlark.Float(float64(*fi.f_) + float64(*n.f_))
 		fi.f_ = &x
 		return nil
 	}
-	return fmt.Errorf("float to int addition not possible")
+	return fmt.Errorf("error with addition: types are not int, float combos")
 }
 
 func (fi floatOrInt) string() string {

--- a/itertools.go
+++ b/itertools.go
@@ -15,7 +15,6 @@ type floatOrInt struct {
 
 // Unpacker for float or int type. This allows int types and float
 // types to interact with one another, e.g. count(0, 0.1).
-// type floatOrInt float6
 func (p *floatOrInt) Unpack(v starlark.Value) error {
 	errorMsg := "floatOrInt must have default initialization"
 

--- a/itertools.go
+++ b/itertools.go
@@ -6,24 +6,115 @@ import (
 	"go.starlark.net/starlark"
 )
 
-type countObject struct {
-	cnt    int
-	step   int
-	frozen bool
-	value  starlark.Value
+// Type that attempts to allow operations between numerics,
+// i.e. float and int.
+type floatOrInt struct {
+	f_ *starlark.Float
+	i_ *starlark.Int
 }
 
-func newCountObject(cnt int, stepValue int) *countObject {
-	return &countObject{cnt: cnt, step: stepValue, value: starlark.MakeInt(cnt)}
+// Unpacker for float or int type. This allows int types and float
+// types to interact with one another, e.g. count(0, 0.1).
+// type floatOrInt float6
+func (p *floatOrInt) Unpack(v starlark.Value) error {
+	errorMsg := "floatOrInt must have default initialization"
+
+	switch v := v.(type) {
+	case starlark.Int:
+		if p.f_ != nil {
+			return fmt.Errorf(errorMsg)
+		}
+		p.i_ = &v
+		return nil
+	case starlark.Float:
+		if p.i_ != nil {
+			return fmt.Errorf(errorMsg)
+		}
+		p.f_ = &v
+		return nil
+	}
+	return fmt.Errorf("got %s, want float or int", v.Type())
+}
+
+func (fi *floatOrInt) add(n floatOrInt) error {
+	switch {
+	case fi.i_ != nil && n.i_ != nil:
+		x := fi.i_.Add(*n.i_)
+		fi.i_ = &x
+		return nil
+	case fi.i_ != nil && n.f_ != nil:
+		x := starlark.Float(float64(fi.i_.Float()) + float64(*n.f_))
+		fi.f_ = &x
+		fi.i_ = nil
+		return nil
+	case fi.f_ != nil && n.i_ != nil:
+		x := starlark.Float(float64(*fi.f_) + float64(n.i_.Float()))
+		fi.f_ = &x
+		fi.i_ = nil
+		return nil
+	case fi.f_ != nil && n.f_ != nil:
+		x := starlark.Float(float64(*fi.f_) + float64(*n.f_))
+		fi.f_ = &x
+		return nil
+	}
+	return fmt.Errorf("float to int addition not possible")
+}
+
+func (fi floatOrInt) string() string {
+	switch {
+	case fi.i_ != nil:
+		return fi.i_.String()
+	case fi.f_ != nil:
+		return fi.f_.String()
+	default:
+		// This block should not be reached.
+		// starlark's String() method is being replicated
+		// so an error is not raised.
+		return ""
+	}
+}
+
+// Equality operator between floatOrInt and starlark's Int, Float
+// and Golang's int.
+func (fi *floatOrInt) eq(v interface{}) bool {
+	switch v := v.(type) {
+	case starlark.Int:
+		if fi.i_ != nil && *fi.i_ == v {
+			return true
+		} else {
+			return false
+		}
+	case starlark.Float:
+		if fi.f_ != nil && *fi.f_ == v {
+			return true
+		} else {
+			return false
+		}
+	case int:
+		if fi.i_ == nil {
+			return false
+		}
+		var x int
+		starlark.AsInt(*fi.i_, &x)
+		return x == v
+	}
+
+	return false
+}
+
+type countObject struct {
+	cnt    floatOrInt
+	step   floatOrInt
+	frozen bool
 }
 
 func (co *countObject) String() string {
 	// As with the cpython implementation, we don't display
-	// step when it is an integer equal to 1.
-	if co.step == 1 {
-		return fmt.Sprintf("count(%v)", co.cnt)
+	// step when it is an integer equal to 1 (default step value).
+	if co.step.eq(1) {
+		return fmt.Sprintf("count(%v)", co.cnt.string())
 	}
-	return fmt.Sprintf("count(%v, %v)", co.cnt, co.step)
+	return fmt.Sprintf("count(%v, %v)", co.cnt.string(), co.step.string())
 }
 
 func (co *countObject) Type() string {
@@ -33,7 +124,6 @@ func (co *countObject) Type() string {
 func (co *countObject) Freeze() {
 	if !co.frozen {
 		co.frozen = true
-		co.value.Freeze()
 	}
 }
 
@@ -58,8 +148,16 @@ func (c *countIter) Next(p *starlark.Value) bool {
 	if c.co.frozen {
 		return false
 	}
-	*p = starlark.MakeInt(c.co.cnt)
-	c.co.cnt += c.co.step
+
+	switch {
+	case c.co.cnt.i_ != nil:
+		*p = c.co.cnt.i_
+	case c.co.cnt.f_ != nil:
+		*p = c.co.cnt.f_
+	}
+
+	c.co.cnt.add(c.co.step)
+
 	return true
 }
 
@@ -72,37 +170,28 @@ func count_(
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
 	var (
-		start int
-		step  int
+		defaultStart            = starlark.MakeInt(0)
+		defaultStep             = starlark.MakeInt(1)
+		start        floatOrInt = floatOrInt{}
+		step         floatOrInt = floatOrInt{}
 	)
 
 	if err := starlark.UnpackPositionalArgs(
 		"count", args, kwargs, 0, &start, &step,
 	); err != nil {
 		return nil, fmt.Errorf(
-			"Got %v but expected NoneType or valid integer values for "+
-				"start and step, such as (0, 1).", args.String(),
+			"Got %v but expected no args, or one or two valid numbers",
+			args.String(),
 		)
 	}
 
-	const (
-		defaultStart = 0
-		defaultStep  = 1
-	)
-	// The rules for populating the count object based on the number
-	// of args passed is as follows:
-	// 	0 args -> default values for start and step
-	// 	1 args -> arg defines start, default for step
-	// 	2 args -> both start and step are defined by args
-	var co_ *countObject
-	switch nargs := len(args); {
-	case nargs == 0:
-		co_ = newCountObject(defaultStart, defaultStep)
-	case nargs == 1:
-		co_ = newCountObject(start, defaultStep)
-	default: // nargs == 2
-		co_ = newCountObject(start, step)
+	// Check if start or step require default values.
+	if start.f_ == nil && start.i_ == nil {
+		start.i_ = &defaultStart
+	}
+	if step.f_ == nil && step.i_ == nil {
+		step.i_ = &defaultStep
 	}
 
-	return co_, nil
+	return &countObject{cnt: start, step: step}, nil
 }

--- a/itertools.go
+++ b/itertools.go
@@ -92,15 +92,8 @@ func (co countObject) String() string {
 	// step when it is an integer equal to 1 (default step value).
 	step, ok := co.step.value.(starlark.Int)
 	if ok {
-		var x int
-		if err := starlark.AsInt(
-			step,
-			&x,
-		); err != nil {
-			panic(err)
-		}
-		if x == 1 {
-			return fmt.Sprintf("count(%v)", co.cnt.String())
+		if x, ok := step.Int64(); ok && x == 1 {
+		         return "count(1)"
 		}
 	}
 

--- a/itertools.go
+++ b/itertools.go
@@ -93,7 +93,7 @@ func (co countObject) String() string {
 	step, ok := co.step.value.(starlark.Int)
 	if ok {
 		if x, ok := step.Int64(); ok && x == 1 {
-			return "count(1)"
+			return fmt.Sprintf("count(%v)", co.cnt.String())
 		}
 	}
 

--- a/itertools.go
+++ b/itertools.go
@@ -95,7 +95,9 @@ func (fi *floatOrInt) eq(v interface{}) bool {
 			return false
 		}
 		var x int
-		starlark.AsInt(*fi.i_, &x)
+		if e := starlark.AsInt(*fi.i_, &x); e != nil {
+			panic(e)
+		}
 		return x == v
 	}
 
@@ -156,7 +158,9 @@ func (c *countIter) Next(p *starlark.Value) bool {
 		*p = c.co.cnt.f_
 	}
 
-	c.co.cnt.add(c.co.step)
+	if e := c.co.cnt.add(c.co.step); e != nil {
+		panic(e)
+	}
 
 	return true
 }

--- a/itertools.go
+++ b/itertools.go
@@ -53,7 +53,7 @@ func (f *floatOrInt) add(n floatOrInt) error {
 		}
 	}
 
-	return fmt.Errorf("cannot compute")
+	return fmt.Errorf("error with addition: types are not int, float combos")
 }
 
 func (f *floatOrInt) String() string {

--- a/testdata/itertools.star
+++ b/testdata/itertools.star
@@ -29,8 +29,97 @@ def test_count():
     assert.eq(str(c2), "count(11, 3)")
     assert.eq(next(c2), 11)
 
+    # Negative args.
+    c3 = count(-5, -10)
+    assert.eq(str(c3), "count(-5, -10)")
+    assert.eq(next(c3), -5)
+    assert.eq(str(c3), "count(-15, -10)")
+    assert.eq(next(c3), -15)
+
+    c4 = count(5, -5)
+    assert.eq(str(c4), "count(5, -5)")
+    assert.eq(next(c4), 5)
+    assert.eq(str(c4), "count(0, -5)")
+    assert.eq(next(c4), 0)
+    assert.eq(str(c4), "count(-5, -5)")
+    assert.eq(next(c4), -5)
+
+    # Int start, float step.
+    c5 = count(0, 0.1)
+    assert.eq(str(c5), "count(0, 0.1)")
+    assert.eq(next(c5), 0)
+    assert.eq(str(c5), "count(0.1, 0.1)")
+    assert.eq(next(c5), 0.1)
+    assert.eq(str(c5), "count(0.2, 0.1)")
+    assert.eq(next(c5), 0.2)
+
+    # Float start, int step — this should be handled same as above
+    # but check to be exhaustive.
+    c6 = count(0.5, 5)
+    assert.eq(str(c6), "count(0.5, 5)")
+    assert.eq(next(c6), 0.5)
+    assert.eq(str(c6), "count(5.5, 5)")
+    assert.eq(next(c6), 5.5)
+    assert.eq(str(c6), "count(10.5, 5)")
+    assert.eq(next(c6), 10.5)
+
+    # This test may seem similar to c5 but is different because
+    # here step > 1. In the case that 0 < step < 1, fmt.Sprintf,
+    # which is used in String(), will display it as a float but
+    # may display it as an int if the proper flags aren't used.
+    c7 = count(5.0, 0.5)
+    assert.eq(str(c7), "count(5.0, 0.5)")
+    assert.eq(next(c7), 5.0)
+    assert.eq(str(c7), "count(5.5, 0.5)")
+    assert.eq(next(c7), 5.5)
+    assert.eq(str(c7), "count(6.0, 0.5)")
+    assert.eq(next(c7), 6.0)
+
+    # NaNs
+    c8 = count(0, float('nan'))
+    assert.eq(str(c8), "count(0, %s)" % (float('nan')))
+    assert.eq(next(c8), 0)
+    assert.eq(str(c8), "count(%s, %s)" % (float('nan'), float('nan')))
+    assert.eq(next(c8), float('nan'))
+    assert.eq(str(c8), "count(%s, %s)" % (float('nan'), float('nan')))
+    assert.eq(next(c8), float('nan'))
+
+    c9 = count(0, float("+inf"))
+    assert.eq(str(c9), "count(0, %s)" % (float("+inf")))
+    assert.eq(next(c9), 0)
+    assert.eq(str(c9), "count(%s, %s)" % (float("+inf"), float("+inf")))
+    assert.eq(next(c9), float("+inf"))
+    assert.eq(str(c9), "count(%s, %s)" % (float("+inf"), float("+inf")))
+    assert.eq(next(c9), float("+inf"))
+
+    c10 = count(0, float("-inf"))
+    assert.eq(str(c10), "count(0, %s)" % (float("-inf")))
+    assert.eq(next(c10), 0)
+    assert.eq(str(c10), "count(%s, %s)" % (float("-inf"), float("-inf")))
+    assert.eq(next(c10), float("-inf"))
+    assert.eq(str(c10), "count(%s, %s)" % (float("-inf"), float("-inf")))
+    assert.eq(next(c10), float("-inf"))
+
+    c11 = count(float("nan"), 2)
+    assert.eq(str(c11), "count(%s, 2)" % (float('nan')))
+    assert.eq(next(c11), float('nan'))
+    assert.eq(str(c11), "count(%s, 2)" % (float('nan')))
+    assert.eq(next(c11), float('nan'))
+
+    c12 = count(float("+inf"), 2)
+    assert.eq(str(c12), "count(%s, 2)" % (float('+inf')))
+    assert.eq(next(c12), float('+inf'))
+    assert.eq(str(c12), "count(%s, 2)" % (float('+inf')))
+    assert.eq(next(c12), float('+inf'))
+
+    c13 = count(float("-inf"), 2)
+    assert.eq(str(c13), "count(%s, 2)" % (float('-inf')))
+    assert.eq(next(c13), float('-inf'))
+    assert.eq(str(c13), "count(%s, 2)" % (float('-inf')))
+    assert.eq(next(c13), float('-inf'))
+
     # Fails
-    z = ("a", "b")
+    # Non-numeric arg fails.
     assert.fails(
         lambda: count("a", "b"),
         # fails uses match under the hood, which will use
@@ -38,6 +127,9 @@ def test_count():
         # that MatchString would accept.
         r'Got \(\"a\", \"b\"\)',
     )
+
+    # Too many arg fails — should be handled by UnpackArgs but
+    # check to be exhaustive.
     assert.fails(
         lambda: count(1, 2, 3),
         r'Got \(1, 2, 3\)'


### PR DESCRIPTION
`itertools.count()` with float and int inputs, implemented with a recipe inspired by `1.` as described [here](https://github.com/tdakkota/sun/pull/10#issuecomment-824533105).

This PR is pretty large because more logic had to be changed than at first anticipated.

@tdakkota This works, as can be seen from the tests, but is pretty complicated (see [`add()`](https://github.com/tdakkota/sun/compare/master...Algebra8:itertools-count-float-input?expand=1#diff-a5603ce7f246714d7bc1f4c42adce50bab121847b739978af58c32bab1f5bb01R49)), and it's not clear what the downstream affects would be, e.g. `Hash()` still has to be implemented and I'm not sure how difficult this will become.

But it does work! 😄 

However, I'm open to slashing this PR in favor of using recipe `2.`, as long as we're ok with always returning a `starlark.Float`.

Curious to hear what you think.